### PR TITLE
feat: add powerstate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ python pylips.py --host %TV's_ip_address% --user %username% --pass %password% --
 ```
 
 **Available built-in commands:**
+1. `powerstate` - Returns the current power state of the TV (`On` or `Off`)
 1. `ambilight_on` - Turns ambilight on
 1. `ambilight_off` - Turns ambilight off
 1. `ambihue_status` - Gets status of 'Ambilight + Hue'

--- a/pylips.py
+++ b/pylips.py
@@ -170,6 +170,9 @@ def main():
     available_commands_get={
         "list_channels": {
             "path": "channeldb/tv/channelLists/all"
+        },
+        "powerstate": {
+            "path": "powerstate"
         }
     }
 


### PR DESCRIPTION
The api returns a JSON object containing the `powerstate` key that can be `On` or `Off`