### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3-slim-bullseye
+
+RUN apt-get update && \
+apt-get install -y --no-install-recommends iputils-ping && \
+rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY [^settings.ini]* .
+
+ENTRYPOINT [ "python", "pylips.py" ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Pylips is a Python tool to control Philips TVs (2015+) through their reverse-eng
 The current version of the API does not allow switching input sources anymore. For Android TVs with Google Assistant, Pylips can switch between any input sources that your TV has. For Android TVs without Google Assistant, see some options [here](#switching-input-sources).
 
 ## Table of contents ##
-1. [Prerequisites](#prerequisites)
+1. [Installation](#installation)
+    1. [Locally](#local)
+    1. [Docker](#docker)
 1. [Setting up Pylips](#setting-up-pylips)
     1. [New users](#new-users)
     1. [Migrating from older versions](#migrating-from-older-versions)
@@ -25,7 +27,9 @@ The current version of the API does not allow switching input sources anymore. F
 1. [Acknowledgements](#acknowledgements)
 1. [Contact details](#contact-details)
 
-## Prerequisites
+## Installation
+
+### Local
 
 Provided that you have python (version 3+) on your system, install all the dependencies first:
 
@@ -34,6 +38,31 @@ pip3 install -r requirements.txt
 ```
 
 You may have to use `pip` and `python` instead of `pip3` and `python3` depending on how these tools are installed on your system.
+
+### Docker
+
+Especially if you want to run pylips continuously to provide the functionality via MQTT, you might want to dockerize pylips.
+
+You need to build the image
+
+```bash
+docker build -t pylips:latest .
+```
+
+and then run it, e.g.,
+
+```bash
+docker run pylips:latest --host 10.0.1.100 --user user --pass password --command powerstate
+```
+
+This requires you to hand-over the `host`, `user` and `pass` parameter every time ([see](#controlling-the-tv-manual-mode)).
+Alternatively, you can use the `settings.ini` file ([see](#new-users)) and mount it in the docker container
+
+```bash
+docker run -v $(pwd)/settings.ini:/usr/src/app/settings.ini pylips:latest
+```
+
+An example docker compose file is given in `docker-compose.yml.example`.
 
 ## Setting up Pylips
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,6 @@
+services:
+  pylips:
+    build: ./
+    volumes:
+      - ./settings.ini:/usr/src/app/settings.ini
+    restart: unless-stopped


### PR DESCRIPTION
Hi,

to let pylips run continously (to provide the API via MQTT) I dockerized the application.
The docker image is based on the slim python image, resulting in an overall image of only ~140MB (on x64/Linux).

If you want to offer the docker image also on dockerhub, I'd be happy to create a pull-request that uses GitHub actions to automatically build and publish a multi-platform image. Just let me know ;)